### PR TITLE
Clarify ownership requirements for swiparr-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ services:
     ports:
       - 4321:4321
 ```
+Make sure that ./swiparr-data is owned by UID 1001:65533 or is writable by this user.
 
 2. Run the container:
 ```bash


### PR DESCRIPTION
Container startup fails with `SqliteError: unable to open database file` if the directory is not writable by UID 1001.